### PR TITLE
Bounds Checker Increment Fix

### DIFF
--- a/framevis.py
+++ b/framevis.py
@@ -143,8 +143,9 @@ class FrameVis:
 			raise ValueError("Invalid direction specified")
 
 		if not quiet:
-			print("Visualizing \"{}\" - {} by {}, from {} frames (every {:.2f} seconds)"\
-				.format(source, output_width, output_height, nframes, FrameVis.interval_from_nframes(source, nframes)))
+			aspect_ratio = output_width / output_height
+			print("Visualizing \"{}\" - {} by {} ({:.2f}), from {} frames (every {:.2f} seconds)"\
+				.format(source, output_width, output_height, aspect_ratio, nframes, FrameVis.interval_from_nframes(source, nframes)))
 
 		# set up for the frame processing loop
 		next_keyframe = keyframe_interval / 2  # frame number for the next frame grab, starting evenly offset from start/end

--- a/framevis.py
+++ b/framevis.py
@@ -440,6 +440,7 @@ class MatteTrimmer:
 				continue  # don't compare bounds, frame bounds are invalid
 
 			video_bounds = frame_bounds if video_bounds is None else MatteTrimmer.find_larger_bound(video_bounds, frame_bounds)
+			next_keyframe += keyframe_interval  # set next frame capture time, maintaining floats
 
 		video.release()  # close video capture
 


### PR DESCRIPTION
Was testing out a few new films and ran into an issue with Kill Bill vol. 1 where the `--trim` parameter wanted to crop the output to 521x158, down from 1920x1080. As it turns out - although I set up the bounds-checking class to check 20 frames from the video file, I never actually incremented that 'next frame' value within the loop. Meaning that the program only checked the first of those 20 frames, and did so 20 times.

For most films this happened to work out fine, where at 1/20th of the way through the movie the frame on screen is at the same aspect ratio as everything else. For *Kill Bill* that frame happened to be during the opening credits, with a small white block of text in the middle of a black background. Oops.

I added the missing line to increment to the next frame, and the trimmer is now correctly checking all 20 frames.

(Also in this pull request: prints the resulting aspect ratio in the 'Visualizing' console output. Just to save the user from doing that bit of mental math)