### PR TITLE
Trim Function Improvements

### DIFF
--- a/framevis.py
+++ b/framevis.py
@@ -403,7 +403,7 @@ class MatteTrimmer:
 		return MatteTrimmer.valid_bounds(image_bounds), image_bounds
 
 	@staticmethod
-	def determine_video_bounds(source, nsamples):
+	def determine_video_bounds(source, nsamples, threshold=2):
 		"""
 		Determines if any matting exists in a video source
 
@@ -411,6 +411,7 @@ class MatteTrimmer:
 			source (str): filepath to source video file
 			nsamples (int): number of frames from the video to determine bounds,
 				evenly spaced throughout the video
+			threshold (8-bit int): min color channel value to judge as 'image present'
 
 		Returns:
 			success (bool): True or False if the bounds are valid
@@ -442,7 +443,7 @@ class MatteTrimmer:
 			if not success:
 				raise IOError("Cannot read from video file")
 			
-			success, frame_bounds = MatteTrimmer.determine_image_bounds(image)
+			success, frame_bounds = MatteTrimmer.determine_image_bounds(image, threshold)
 
 			if not success:
 				continue  # don't compare bounds, frame bounds are invalid

--- a/framevis.py
+++ b/framevis.py
@@ -371,7 +371,7 @@ class MatteTrimmer:
 		return True
 
 	@staticmethod
-	def determine_image_bounds(image, threshold=1):
+	def determine_image_bounds(image, threshold=2):
 		"""
 		Determines if there are any hard mattes (black bars) surrounding
 		an image on either the top (letterboxing) or the sides (pillarboxing)

--- a/framevis.py
+++ b/framevis.py
@@ -84,7 +84,8 @@ class FrameVis:
 			if not quiet:
 				print("Trimming enabled, checking matting... ", end="", flush=True)
 
-			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 10)  # 10 frame samples
+			# 10 frame samples, seen as matted if an axis has all color channels at 2 / 255 or lower (avg)
+			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 10, 2)
 
 			matte_type = 0
 			if success:  # only calculate cropping if bounds are valid
@@ -371,7 +372,7 @@ class MatteTrimmer:
 		return True
 
 	@staticmethod
-	def determine_image_bounds(image, threshold=2):
+	def determine_image_bounds(image, threshold):
 		"""
 		Determines if there are any hard mattes (black bars) surrounding
 		an image on either the top (letterboxing) or the sides (pillarboxing)
@@ -403,7 +404,7 @@ class MatteTrimmer:
 		return MatteTrimmer.valid_bounds(image_bounds), image_bounds
 
 	@staticmethod
-	def determine_video_bounds(source, nsamples, threshold=2):
+	def determine_video_bounds(source, nsamples, threshold):
 		"""
 		Determines if any matting exists in a video source
 

--- a/framevis.py
+++ b/framevis.py
@@ -371,13 +371,14 @@ class MatteTrimmer:
 		return True
 
 	@staticmethod
-	def determine_image_bounds(image):
+	def determine_image_bounds(image, threshold=1):
 		"""
 		Determines if there are any hard mattes (black bars) surrounding
 		an image on either the top (letterboxing) or the sides (pillarboxing)
 
 		Parameters:
 			image (arr, x.y.c): image as 3-dimensional numpy array
+			threshold (8-bit int): min color channel value to judge as 'image present'
 
 		Returns:
 			success (bool): True or False if the bounds are valid
@@ -389,13 +390,13 @@ class MatteTrimmer:
 
 		# check for letterboxing
 		horizontal_sums = np.sum(image, axis=(1,2))  # sum all color channels across all rows
-		threshold = (width * depth)  # must be below every pixel having a value of 1/255 in every channel
-		vertical_edges = MatteTrimmer.find_matrix_edges(horizontal_sums, threshold)
+		hthreshold = (threshold * width * depth)  # must be below every pixel having a value of "threshold" in every channel
+		vertical_edges = MatteTrimmer.find_matrix_edges(horizontal_sums, hthreshold)
 
 		# check for pillarboxing
 		vertical_sums = np.sum(image, axis=(0,2))  # sum all color channels across all columns
-		threshold = (height * depth)  # must be below every pixel having a value of 1/255 in every channel
-		horizontal_edges = MatteTrimmer.find_matrix_edges(vertical_sums, threshold)
+		vthreshold = (threshold * height * depth)  # must be below every pixel having a value of "threshold" in every channel
+		horizontal_edges = MatteTrimmer.find_matrix_edges(vertical_sums, vthreshold)
 
 		image_bounds = np.array([[horizontal_edges[0], vertical_edges[0]], [horizontal_edges[1], vertical_edges[1]]])
 

--- a/framevis.py
+++ b/framevis.py
@@ -84,8 +84,8 @@ class FrameVis:
 			if not quiet:
 				print("Trimming enabled, checking matting... ", end="", flush=True)
 
-			# 10 frame samples, seen as matted if an axis has all color channels at 2 / 255 or lower (avg)
-			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 10, 2)
+			# 10 frame samples, seen as matted if an axis has all color channels at 3 / 255 or lower (avg)
+			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 10, 3)
 
 			matte_type = 0
 			if success:  # only calculate cropping if bounds are valid

--- a/framevis.py
+++ b/framevis.py
@@ -426,6 +426,12 @@ class MatteTrimmer:
 			raise ValueError("Number of samples must be a positive integer")
 		keyframe_interval = video_total_frames / nsamples  # calculate number of frames between captures
 
+		# open video to make results consistent with visualizer
+		# (this also GREATLY increases the read speed? no idea why)
+		success,image = video.read()  # get first frame
+		if not success:
+			raise IOError("Cannot read from video file")
+
 		next_keyframe = keyframe_interval / 2  # frame number for the next frame grab, starting evenly offset from start/end
 		video_bounds = None
 

--- a/framevis.py
+++ b/framevis.py
@@ -84,7 +84,7 @@ class FrameVis:
 			if not quiet:
 				print("Trimming enabled, checking matting... ", end="", flush=True)
 
-			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 20)  # 20 frame samples
+			success, cropping_bounds = MatteTrimmer.determine_video_bounds(source, 10)  # 10 frame samples
 
 			matte_type = 0
 			if success:  # only calculate cropping if bounds are valid


### PR DESCRIPTION
This PR includes several changes to improve the 'trim' functionality:

* Now samples 10 frames instead of 20 (speed improvements)
* The threshold for judging matting has been increased / made more aggressive (from 1/255 to 3/255)
* The threshold can now be overridden when calling the bounds evaluation functions directly

This also fixes a strange error with video reading that made the sampled 'trim' frames different than the frames used for the visualizer, even when the frames were set to the same sampling interval. Doing a single video 'read' before beginning the trim sampling loop greatly increases the processing speed and makes the sampled frames line up with the visualized ones. I don't know why.

My guess is that this has to do with interpolation and key framing with the H.264 codec, but that's just a hunch. It looks like there are a few OpenCV bug issues floating around having to do with video frame position, so I'm not going to bother looking deeper other than to say it's probably out of my hands.

I also considered rewriting the matting determination functions to work on a per-pixel basis rather than per-axis, but I didn't want to incur the performance penalty. Since 10 frames are already used and the algorithm takes the largest bound from all of them, I think the faster shotgun approach works well enough.